### PR TITLE
Use owasm-std 0.10 and bump to 0.1.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,7 @@ exclude = [ "tests/*", "derive/*" ]
 panic = "abort"
 
 [dependencies]
-#owasm-std = "0.12"
-owasm-std = { git = "https://github.com/oasislabs/owasm-std", branch = "0.10.0" }
+owasm-std = "0.10"
 
 [dependencies.uint]
 version = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [ "tests/*", "derive/*" ]
 panic = "abort"
 
 [dependencies]
-pwasm-std = "0.10"
+owasm-std = "0.12"
 
 [dependencies.uint]
 version = "0.4"
@@ -31,5 +31,5 @@ hex-literal = "0.1"
 
 [features]
 default = ["std"]
-std = ["uint/std", "pwasm-std/std"]
+std = ["uint/std", "owasm-std/std"]
 strict = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,8 @@ exclude = [ "tests/*", "derive/*" ]
 panic = "abort"
 
 [dependencies]
-owasm-std = "0.12"
+#owasm-std = "0.12"
+owasm-std = { git = "https://github.com/oasislabs/owasm-std", branch = "0.10.0" }
 
 [dependencies.uint]
 version = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "owasm-abi"
-version = "0.1.12"
+version = "0.1.13"
 authors = ["NikVolf <nikvolf@gmail.com>", "Oasis Labs <info@oasislabs.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 
 extern crate byteorder;
 extern crate uint;
-extern crate pwasm_std;
+extern crate owasm_std;
 
 #[cfg(test)]
 #[macro_use]
@@ -21,8 +21,8 @@ pub mod eth;
 
 /// Custom types which AbiType supports
 pub mod types {
-	pub use pwasm_std::Vec;
-	pub use pwasm_std::hash::*;
+	pub use owasm_std::Vec;
+	pub use owasm_std::hash::*;
 	pub use uint::U256;
 }
 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 authors = ["NikVolf <nikvolf@gmail.com>"]
 
 [dependencies]
-pwasm-std = "0.10"
+owasm-std = "0.10"
 pwasm-test = { git = "https://github.com/paritytech/pwasm-test", optional = true }
 owasm-abi = { path = "..", default-features=false }
 owasm-abi-derive = { path = "../derive" }
@@ -12,4 +12,4 @@ owasm-ethereum = "0.7.0"
 
 [features]
 default = []
-test = ["pwasm-test", "pwasm-std/std", "owasm-ethereum/std"]
+test = ["pwasm-test", "owasm-std/std", "owasm-ethereum/std"]

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -5,7 +5,7 @@
 #![feature(proc_macro_hygiene)]
 #![cfg(test)]
 
-extern crate pwasm_std;
+extern crate owasm_std;
 extern crate owasm_ethereum;
 extern crate pwasm_test;
 extern crate owasm_abi;

--- a/tests/src/payable.rs
+++ b/tests/src/payable.rs
@@ -3,7 +3,7 @@
 use owasm_abi_derive::eth_abi;
 use owasm_abi::eth::EndpointInterface;
 
-use owasm_test::{ext_reset};
+use pwasm_test::{ext_reset};
 
 const PAYLOAD_BAZ: &[u8] = &[
 	0xcd, 0xcd, 0x77, 0xc0,

--- a/tests/src/payable.rs
+++ b/tests/src/payable.rs
@@ -3,7 +3,7 @@
 use owasm_abi_derive::eth_abi;
 use owasm_abi::eth::EndpointInterface;
 
-use pwasm_test::{ext_reset};
+use owasm_test::{ext_reset};
 
 const PAYLOAD_BAZ: &[u8] = &[
 	0xcd, 0xcd, 0x77, 0xc0,


### PR DESCRIPTION
I tried using v0.12 but there was an issue here: https://github.com/rust-random/rand/issues/503 that made the builds break for `wasm32-unknown-unknown`.